### PR TITLE
add my sourceforge binary dump

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -47,6 +47,7 @@ whitelist = [
 	# You're naughty, so you get to sit in the corner, away from the other URLs
 	"sourceforge.net/projects/pcre/files/pcre/[^/]+/[^/]+/download",
 	"downloads.sourceforge.net/sevenzip",
+	"sourceforge.net/projects/juliadeps-win/files/[^/]+/download",
 ]
 
 # Take a stripped-down URL and add all the regex stuff to make it something we'd have dinner with


### PR DESCRIPTION
Sorry to have to do this, but a few packages in juliaopt and elsewhere that aren't large enough to be worth submitting to opensuse are still using this, and it's unreliable and annoying as sourceforge tends to be. Figured this is an effective way to get them onto S3 without too much manual intervention :)
