### PR TITLE
Add wcslib ftp address to whitelist

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -57,6 +57,7 @@ whitelist = [
 	"imagemagick.org/download/binaries",
 	"tls.mbed.org/download",
 	"thrysoee.dk/editline",
+	"ftp.atnf.csiro.au/pub/software/wcslib",
 
 	# Add unicode fonts for libutf8
 	"unicode.org/Public/UCD/latest/ucd/auxiliary",


### PR DESCRIPTION
As suggested in JuliaLang/METADATA.jl#5739. (Tony wasn't sure if this would work with ftp.)
