### PR TITLE
add another UnicodeData.txt location to whitelist

### DIFF
--- a/cache/cache.py
+++ b/cache/cache.py
@@ -450,6 +450,7 @@ whitelist = [
     "unicode.org/Public/UCD/latest/ucd/auxiliary",
     "unicode.org/Public/UNIDATA",
     "unifoundry.com/pub/unifont-[\d\.]+/font-builds",
+    "unicode.org/Public/[\d\.]+/ucd",
 
     # Sourceforge URLs
     "sourceforge.net/projects/pcre/files/pcre/[^/]+",


### PR DESCRIPTION
cc @staticfloat this right? anything needed to deploy this or does it happen automatically on merge? this (currently http://www.unicode.org/Public/9.0.0/ucd/UnicodeData.txt but may change) is downloaded in `doc/Makefile` and it's been flaky on travis lately