### PR TITLE
Allow caching `ftp.gnu.org`

### DIFF
--- a/cache/cache.py
+++ b/cache/cache.py
@@ -420,6 +420,7 @@ whitelist = [
 
     # Various deps/ tarball locations
     "faculty.cse.tamu.edu/davis/SuiteSparse",
+    "ftp.gnu.org/gnu",
     "download.savannah.gnu.org/releases/libunwind",
     "github.com/[^/]+/[^/]+/archive",
     "github.com/[^/]+/[^/]+/releases/download/([^/]+)?",


### PR DESCRIPTION
`ftp.gnu.org` is apparently quite strict when it detects abuse. We download packages usually 12 times simultaneously, triggering the abuse detector, and we thus have trouble building GNU software.

@staticfloat